### PR TITLE
Remove toolchain include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
 
-if(CMAKE_TOOLCHAIN_FILE)
-  include(${CMAKE_TOOLCHAIN_FILE})
-endif()
-
 option(BUILD_TESTS "Configure CMake to build tests (or not)" ON)
 option(BUILD_EXAMPLES "Configure CMake to build examples (or not)" ON)
 option(COVERAGE "Enable code coverage testing" OFF)


### PR DESCRIPTION
When you specify toolchain file, cmake makes the variables from it available to all CMakeLists, that is cmake includes this file for you if you specifiy -DCMAKE_TOOLCHAIN_FILE.

This also breaks crosscompilation for me when I use this library, when removed everything works fine.

What is the reasoning behind this? Am I missing something?